### PR TITLE
Add Rest API client (Java)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,4 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 - [granary](https://granary.io/) (Python, REST API) converts `app.bsky` objects to/from ActivityStreams, RSS, Atom, HTML, and more
 - [Bridgy Fed](https://fed.brid.gy/) (Python) includes implementations of the [AT Protocol Merkle search tree](https://github.com/snarfed/bridgy-fed/blob/main/atproto_mst.py) and [`com.atproto.sync`](https://github.com/snarfed/bridgy-fed/blob/main/atproto.py)
 - [bsky-link-preview](https://github.com/capjamesg/bsky-link-preview): Generate an embeddable link preview for a Bluesky post.
+- [bluesky-api-client](https://github.com/smileostrich/bluesky-api-client): This is Rest API client for BlueSky written by Java. Providing interesting methods(checking followers, followings by automatically) and helper methods for fetching likes list, authentication, fetching timelines and other interesting supports.


### PR DESCRIPTION
Add Rest API client (Java) - "bluesky-api-client"

### Description
This is Rest API client for BlueSky API. Providing interesting methods(checking followers, followings by automatically) and helper methods for fetching likes list, authentication, fetching timelines and other interesting supports

### Github
https://github.com/smileostrich/bluesky-api-client